### PR TITLE
[#263] BUGFIX Work Order Search

### DIFF
--- a/backend/src/repositories/WorkOrderRepository.ts
+++ b/backend/src/repositories/WorkOrderRepository.ts
@@ -1,7 +1,7 @@
 import { WorkOrder } from '../entities/WorkOrder';
 import { Property } from '../entities/Property';
 import { BaseRepository } from './BaseRepository';
-import { FindOptions } from 'typeorm';
+import { FindOptions, Brackets } from 'typeorm';
 import { OrderingByType } from '../enums/OrderingByType';
 
 class WorkOrderRepository extends BaseRepository<WorkOrder> {
@@ -12,22 +12,28 @@ class WorkOrderRepository extends BaseRepository<WorkOrder> {
 
     async getWorkOrders(filterQueries: string, pageNumber: number, pageSize: number,
                         searchTerm: string, workOrderSort: string, ordering: OrderingByType) {
+
         return await this.getRepositoryConnection(WorkOrder)
-            .createQueryBuilder('work_orders')
-            .addSelect(['properties.id', 'createdBy.id', 'lastModifiedBy.id'])
-            .leftJoinAndSelect('work_orders.sector', 'sector')
-            .leftJoinAndSelect('work_orders.priorityType', 'priorityType')
-            .leftJoin('work_orders.property', 'properties')
-            .leftJoin('work_orders.createdBy', 'createdBy')
-            .leftJoinAndSelect('work_orders.workOrderType', 'workOrderType')
-            .leftJoin('work_orders.lastModifiedBy', 'lastModifiedBy')
-            .leftJoinAndSelect('work_orders.workOrderStatus', 'workOrderStatus')
-            .where(filterQueries)
-            .andWhere(searchTerm != null  ? 'concat(cause, title, location, notification) like :searchTerm' : '1=1', { searchTerm: '%' + searchTerm + '%' })
-            .orderBy(workOrderSort, ordering)
-            .skip(pageSize * (pageNumber - 1))
-            .take(pageSize)
-            .getMany();
+        .createQueryBuilder('work_orders')
+        .addSelect(['properties.id', 'createdBy.id', 'lastModifiedBy.id'])
+        .leftJoinAndSelect('work_orders.sector', 'sector')
+        .leftJoinAndSelect('work_orders.priorityType', 'priorityType')
+        .leftJoin('work_orders.property', 'properties')
+        .leftJoin('work_orders.createdBy', 'createdBy')
+        .leftJoinAndSelect('work_orders.workOrderType', 'workOrderType')
+        .leftJoin('work_orders.lastModifiedBy', 'lastModifiedBy')
+        .leftJoinAndSelect('work_orders.workOrderStatus', 'workOrderStatus')
+        .where(filterQueries)
+        .andWhere(searchTerm != null ? new Brackets(b => {
+                b.where("work_orders.cause like :searchTerm", { searchTerm: '%' + searchTerm + '%' })
+                .orWhere("work_orders.title like :searchTerm", { searchTerm: '%' + searchTerm + '%' })
+                .orWhere("work_orders.location like :searchTerm", { searchTerm: '%' + searchTerm + '%' })
+                .orWhere("work_orders.notification like :searchTerm", { searchTerm: '%' + searchTerm + '%' })})
+                : '1=1')
+        .orderBy(workOrderSort, ordering)
+        .skip(pageSize * (pageNumber - 1))
+        .take(pageSize)
+        .getMany();
     }
 
     async getWorkOrdersByProperty(property: Property, fieldOptions?: FindOptions<WorkOrder>) {


### PR DESCRIPTION
Refactored form of where clause that compares work order columns to searchTerm in WorkOrderRepository.

Replaced concat with Brackets and individual where-like comparisons. 

Work Order Search now searches according to the following partial query:
WHERE (
workOrder.title LIKE %searchTerm% 
OR 
workOrder.cause LIKE %searchTerm% 
OR 
workOrder.location LIKE %searchTerm% 
OR 
workOrder.notification LIKE %searchTerm%)




